### PR TITLE
Add FourPeaksGenerator class import to top-level init file

### DIFF
--- a/src/mlrose_ky/__init__.py
+++ b/src/mlrose_ky/__init__.py
@@ -55,7 +55,7 @@ from .opt_probs import DiscreteOpt, ContinuousOpt, KnapsackOpt, TSPOpt, QueensOp
 from .runners import GARunner, MIMICRunner, RHCRunner, SARunner, NNGSRunner, SKMLPRunner, build_data_filename
 
 # noinspection PyUnresolvedReferences
-from .generators import MaxKColorGenerator, QueensGenerator, FlipFlopGenerator, TSPGenerator, KnapsackGenerator, ContinuousPeaksGenerator
+from .generators import MaxKColorGenerator, QueensGenerator, FlipFlopGenerator, TSPGenerator, KnapsackGenerator, ContinuousPeaksGenerator, FourPeaksGenerator
 
 # noinspection PyUnresolvedReferences
 from .samples import SyntheticData, plot_synthetic_dataset


### PR DESCRIPTION
Glad someone is finally modernizing mlrose! I just pushed a fix to [hiive/mlrose](https://github.com/hiive/mlrose/pull/36) last week so thought I'd add it here as well.

Issue: Missing top-level import for the FourPeaksGenerator class I made last year. You guys caught the generator module level one.