### PR TITLE
Fixing stop_fitness for QueensOpt with custom fitness fn

### DIFF
--- a/src/mlrose_ky/opt_probs/queens_opt.py
+++ b/src/mlrose_ky/opt_probs/queens_opt.py
@@ -55,6 +55,7 @@ class QueensOpt(DiscreteOpt):
         maximize: bool = False,
         crossover: "UniformCrossOver" = None,
         mutator: "ChangeOneMutator" = None,
+        stop_fitness: int = None,
     ):
         # Ensure that either fitness_fn or length is provided
         if fitness_fn is None and length is None:
@@ -73,9 +74,12 @@ class QueensOpt(DiscreteOpt):
         # If fitness_fn is not provided, create a new Queens fitness function
         if fitness_fn is None:
             fitness_fn = Queens(maximize=maximize)
-
-        # Set the stopping fitness value based on whether we're maximizing or minimizing
-        self.stop_fitness: int = Queens.get_max_size(length) if maximize else 0
+            # Set the stopping fitness value based on whether we're maximizing or minimizing
+            self.stop_fitness: int = Queens.get_max_size(length) if maximize else 0
+        else:
+            if stop_fitness is None:
+                raise ValueError("Expected stop_fitness to be defined for custom fitness_fn")
+            self.stop_fitness = stop_fitness
 
         # Set max_val to length, as it represents the board size
         self.max_val: int = length

--- a/tests/test_opt_probs/test_queens_opt.py
+++ b/tests/test_opt_probs/test_queens_opt.py
@@ -39,7 +39,7 @@ class TestQueensOpt:
         """Test that the QueensOpt class is initialized correctly when length is inferred from weights."""
         fitness_fn = FlipFlop()
         fitness_fn.weights = np.ones(5).tolist()
-        queens_opt = QueensOpt(fitness_fn=fitness_fn)
+        queens_opt = QueensOpt(fitness_fn=fitness_fn, stop_fitness=5)
 
         assert queens_opt.length == 5
         assert queens_opt.max_val == 5
@@ -72,6 +72,18 @@ class TestQueensOpt:
 
         queens_opt.set_state(np.array([0, 6, 4, 7, 1, 3, 5, 2]))
         assert queens_opt.can_stop()
+
+    def test_custom_fn_without_stop_fitness(self):
+        with pytest.raises(ValueError, match="Expected stop_fitness to be defined for custom fitness_fn"):
+            _ = QueensOpt(length=8, fitness_fn=mlrose_ky.CustomFitness(lambda x: 0, problem_type="discrete"))
+
+    def test_can_stop_custom_stop_fitness(self):
+        BEST_FITNESS = 5;
+        problem = QueensOpt(length=4,fitness_fn=mlrose_ky.CustomFitness(lambda x: 0), stop_fitness=BEST_FITNESS)
+        problem.fitness = BEST_FITNESS
+        assert problem.can_stop()
+        problem.fitness = BEST_FITNESS - 1
+        assert not problem.can_stop()
 
     def test_random_state_generation(self):
         """Test that random state generation produces valid states."""


### PR DESCRIPTION
Fixing the issue described here by allowing custom stop_fitness instead of using the default for custom fitness function 

https://github.com/knakamura13/mlrose-ky/issues/32