### PR TITLE
Fix Queens Fitness Evaluation

### DIFF
--- a/src/mlrose_ky/fitness/queens.py
+++ b/src/mlrose_ky/fitness/queens.py
@@ -91,12 +91,7 @@ class Queens:
         int
             Maximum possible number of conflicts.
         """
-        if problem_size <= 1:
-            return 0
-        if problem_size == 2:
-            return 1
-
-        return 3 * (problem_size - 2)
+        return (problem_size * (problem_size - 1)) / 2
 
     def evaluate(self, state: np.ndarray) -> float:
         """Evaluate the fitness of a state vector.
@@ -120,7 +115,7 @@ class Queens:
             raise TypeError(f"Expected state to be np.ndarray, got {type(state).__name__} instead.")
 
         # Check for horizontal conflicts (queens in the same row)
-        horizontal_conflicts = np.sum(np.unique(state, return_counts=True)[1] - 1)
+        horizontal_conflicts = np.multiply(np.unique(state, return_counts=True)[1], np.unique(state, return_counts=True)[1] - 1).sum() // 2
 
         size = state.size
 

--- a/tests/test_opt_probs/test_queens_opt.py
+++ b/tests/test_opt_probs/test_queens_opt.py
@@ -87,7 +87,7 @@ class TestQueensOpt:
         state = np.array([0, 0, 0, 0, 0, 0, 0, 0])
         queens_opt.set_state(state)
 
-        assert queens_opt.get_fitness() == -7
+        assert queens_opt.get_fitness() == -28
 
     def test_fitness_evaluation_optimal_state(self):
         """Test fitness evaluation for an optimal state."""


### PR DESCRIPTION
When using mlrose-ky and running a Queens Problem (maximization = True) through the Genetic RO algorithm, I encounter the following error: 

> ValueError: probabilities are not non-negative

**To reproduce this error, please run the following code:**
```
import mlrose_ky as mlrose

test_problem = mlrose.opt_probs.QueensOpt(length = 5, maximize = True)

for i in range(1000):
    runner = mlrose.GARunner(
        population_sizes = [5],
        mutation_rates = [0.01],
        problem = test_problem, 
        experiment_name = "queens-fitness-error", 
        iteration_list = [101, 102, 103],
        max_attempts = 50,
        seed = i, 
        generate_curves = True
    )
    runner.run()

# seeds where this doesn't work
# 61
# 395
# 724
# 790
# 886
```

I reviewed the source code in mlrose-ky fork and found this is related to state fitnesses being negative in some cases for Queens problem. I identified 2 issues:

1. The number of horizontal conflicts is undercounted
2. The "maximum possible number of conflicts" is also undercounted -- this is needed to invert the fitness function properly for maximization (by default Queens problem minimizes the number of conflicts)

Let me know if you have any questions.