### PR TITLE
Fixing the Decay String for GeomDecay

### DIFF
--- a/src/mlrose_ky/algorithms/decay/geom_decay.py
+++ b/src/mlrose_ky/algorithms/decay/geom_decay.py
@@ -54,7 +54,7 @@ class GeomDecay:
             raise ValueError("Minimum temperature must be greater than 0 and less than initial temperature.")
 
     def __str__(self):
-        return str(self.init_temp)
+        return f"GeomDecay(init_temp={self.init_temp}, decay={self.decay}, min_temp={self.min_temp})"
 
     def __repr__(self):
         return f"{self.__class__.__name__}(init_temp={self.init_temp}, decay={self.decay}, min_temp={self.min_temp})"

--- a/tests/test_algorithms/test_algorithms__decay.py
+++ b/tests/test_algorithms/test_algorithms__decay.py
@@ -38,7 +38,7 @@ class TestAlgorithmsDecay:
     def test_geom_decay_str_repr(self):
         """Test GeomDecay __str__ and __repr__ methods."""
         schedule = GeomDecay(init_temp=10, decay=0.95, min_temp=1)
-        assert str(schedule) == "10"
+        assert str(schedule) == "GeomDecay(init_temp=10, decay=0.95, min_temp=1)"
         assert repr(schedule) == "GeomDecay(init_temp=10, decay=0.95, min_temp=1)"
 
     def test_geom_decay_eq(self):


### PR DESCRIPTION
GeomDecay String method is giving only the initTemp and not the entire string thus not matching ArithDecay and ExpDecay. Fixing the same for consistency and correct result string.

![image](https://github.com/user-attachments/assets/f8df9190-8ff8-4061-875f-2ccc835abf50)
